### PR TITLE
Private access Documentation Review recommendations

### DIFF
--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaPrivateAccessApplicationSegment.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaPrivateAccessApplicationSegment.md
@@ -17,46 +17,57 @@ schema: 2.0.0
 # Get-EntraBetaPrivateAccessApplicationSegment
 
 ## Synopsis
-The Get-EntraBetaPrivateAccessApplicationSegment cmdlet retrieves a list of all application segments associated to a Private Access application, or if specified, details of a specific application segment.
+
+Retrieves a list of all application segments associated to a Private Access application, or if specified, details of a specific application segment.
 
 ## Description
-The Get-EntraBetaPrivateAccessApplicationSegment cmdlet retrieves a list of all application segments associated to a Private Access application, or if specified, details of a specific application segment.
+
+The `Get-EntraBetaPrivateAccessApplicationSegment` cmdlet retrieves a list of all application segments associated to a Private Access application, or if specified, details of a specific application segment.
 
 ## Examples
 
 ### Example 1: Retrieve all application segments associated to an application
+
 ```powershell
-PS C:\> Get-EntraBetaPrivateAccessApplicationSegment -ObjectId b97db9dd-85c7-4365-ac05-bd824728ab83
+Get-EntraBetaPrivateAccessApplicationSegment -ObjectId '00001111-aaaa-2222-bbbb-3333cccc4444'
 ```
-```output
+
+```Output
 destinationHost : 10.1.1.20
 destinationType : ip
 port            : 0
 ports           : {22-22}
 protocol        : tcp
-id              : 89a0ff5a-0440-4411-8f1c-d4e0be0635c8
+id              : cccc2222-dd33-4444-55ee-666666ffffff
 
 destinationHost : 10.20.20.20
 destinationType : ip
 port            : 0
 ports           : {8080-8080}
 protocol        : tcp
-id              : 47da55f4-26b1-47ab-a34c-20a86a5e22a7
+id              : cccc2222-dd33-4444-55ee-666666ffffff
 ```
 
 This command retrieves all application segments for an application.
 
 ### Example 2: Retrieve a specific application segment associated to an application
+
 ```powershell
-PS C:\> Get-EntraBetaPrivateAccessApplicationSegment b97db9dd-85c7-4365-ac05-bd824728ab83 -ApplicationSegmentId 89a0ff5a-0440-4411-8f1c-d4e0be0635c8
+$params = @{
+    ObjectId = '00001111-aaaa-2222-bbbb-3333cccc4444'
+    ApplicationSegmentId = 'cccc2222-dd33-4444-55ee-666666ffffff'
+}
+
+Get-EntraBetaPrivateAccessApplicationSegment @params
 ```
-```output
+
+```Output
 destinationHost : 10.1.1.20
 destinationType : ip
 port            : 0
 ports           : {22-22}
 protocol        : tcp
-id              : 89a0ff5a-0440-4411-8f1c-d4e0be0635c8
+id              : cccc2222-dd33-4444-55ee-666666ffffff
 ```
 
 This example demonstrates how to retrieve information for a specific application segment.
@@ -64,10 +75,11 @@ This example demonstrates how to retrieve information for a specific application
 ## Parameters
 
 ### -ObjectId
-The object id of a Private Access application object.
+
+The Object ID of a Private Access application object.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: AllApplicationSegments, SingleApplicationSegment
 Aliases: id
 
@@ -79,10 +91,11 @@ Accept wildcard characters: False
 ```
 
 ### -ApplicationSegmentId
+
 Specifies a specific application segment to retrieve.
 
 ```yaml
-Type: String
+Type: System.String
 Parameter Sets: SingleApplicationSegment
 Aliases:
 
@@ -94,16 +107,19 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## Inputs
 
 ### System.String
+
 System.Nullable\`1\[\[System. Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\]\] System.Nullable\`1\[\[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\]\]
 
 ## Outputs
 
 ### System.Object
+
 ## Notes
 
 ## RELATED LINKS

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaPrivateAccessApplicationSegment.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaPrivateAccessApplicationSegment.md
@@ -4,7 +4,7 @@ description: This article provides details on the New-EntraBetaPrivateAccessAppl
 
 ms.topic: reference
 ms.date: 07/18/2024
-ms.author: andresc
+ms.author: eunicewaweru
 ms.reviewer: stevemutungi
 manager: CelesteDG
 author: andres-canello
@@ -17,77 +17,100 @@ schema: 2.0.0
 # New-EntraBetaPrivateAccessApplicationSegment
 
 ## Synopsis
-The New-EntraBetaPrivateAccessApplicationSegment cmdlet creates an application segments associated to a Private Access application.
+
+Creates an application segments associated to a Private Access application.
 
 ## Description
-The New-EntraBetaPrivateAccessApplicationSegment cmdlet creates an application segments associated to a Private Access application.
+
+The `New-EntraBetaPrivateAccessApplicationSegment` cmdlet creates an application segments associated to a Private Access application.
 
 ## Examples
 
 ### Example 1: Create a simple application segment
+
 ```powershell
-PS C:\> New-EntraBetaPrivateAccessApplicationSegment -ObjectId b97db9dd-85c7-4365-ac05-bd824728ab83 -DestinationHost ssh.contoso.local -Ports 22 -Protocol TCP -DestinationType FQDN
+New-EntraBetaPrivateAccessApplicationSegment -ObjectId '00001111-aaaa-2222-bbbb-3333cccc4444' -DestinationHost 'ssh.contoso.local' -Ports 22 -Protocol TCP -DestinationType FQDN
 ```
-```output
+
+```Output
 destinationHost : ssh.contoso.local
 destinationType : FQDN
 port            : 0
 ports           : {22-22}
 protocol        : tcp
-id              : 89a0ff5a-0440-4411-8f1c-d4e0be0635c8
+id              : cccc2222-dd33-4444-55ee-666666ffffff
 ```
 
 ### Example 2: Create an application segment using ranges of IPs and multiple ports
+
 ```powershell
-PS C:\> New-EntraBetaPrivateAccessApplicationSegment -ObjectId b97db9dd-85c7-4365-ac05-bd824728ab83 -DestinationHost 192.168.1.100..192.168.1.110 -Ports 22,3389 -Protocol TCP,UDP -DestinationType ipRange
+$params = @{
+    ObjectId = '00001111-aaaa-2222-bbbb-3333cccc4444'
+    DestinationHost = '192.168.1.100..192.168.1.110'
+    Ports = '22,3389'
+    Protocol = 'TCP,UDP'
+    DestinationType = 'ipRange'
+}
+
+New-EntraBetaPrivateAccessApplicationSegment @params
 ```
-```output
+
+```Output
 destinationHost : 192.168.1.100..192.168.1.110
 destinationType : ipRange
 port            : 0
 ports           : {22-22, 3389-3389}
 protocol        : tcp,udp
-id              : 36b4dd89-3a6f-44b8-9e5b-d5be08688977
+id              : cccc2222-dd33-4444-55ee-666666ffffff
 ```
 
 ### Example 3: Create application segments using an input file
 
 AppSegments.csv
 
-AppOId,DestHost,ports,protocol,type\
-58c59e74-5b92-4578-bef5-36b86ac97f0a,10.106.97.0/24,"1-21,23-442,444-65535","TCP,udp",ipRangeCidr\
-58c59e74-5b92-4578-bef5-36b86ac97f0a,10.106.96.0/24,"1-21,23-442,444-65535","udp",ipRangeCidr\
-58c59e74-5b92-4578-bef5-36b86ac97f0a,10.106.95.0/24,"1-21","udp",ipRangeCidr
+AppObjectId,DestHost,ports,protocol,type\
+00001111-aaaa-2222-bbbb-3333cccc4444,10.106.97.0/24,"1-21,23-442,444-65535","TCP,udp",ipRangeCidr\
+00001111-aaaa-2222-bbbb-3333cccc4444,10.106.96.0/24,"1-21,23-442,444-65535","udp",ipRangeCidr\
+00001111-aaaa-2222-bbbb-3333cccc4444,10.106.95.0/24,"1-21","udp",ipRangeCidr
 
 CreateAppSegments.ps1
+
 ```powershell
-﻿$csvFile = "C:\temp\AppSegments.csv"
- 
-# Assuming the CSV file has columns named 'AppOId', 'DestHost', 'ports', 'protocol', 'type'
+$csvFile = "C:\temp\AppSegments.csv"
+
+# Assuming the CSV file has columns named 'AppObjectId', 'DestHost', 'ports', 'protocol', 'type'
 $variables = Import-Csv $csvFile
- 
+
 # Loop through each row of the CSV and execute the command for each set of variables
 foreach ($variable in $variables) {
-    $AppOId = $variable.AppOId
+    $AppObjectId = $variable.AppObjectId
     $DestHost = $variable.DestHost
     $ports = $variable.ports -split ","
     $protocol = $variable.protocol -split ","
     $type = $variable.type
- 
+
     # Execute the command
-    New-EntraBetaPrivateAccessApplicationSegment -ObjectId $AppOId -DestinationHost $DestHost -Ports $ports -Protocol $protocol -DestinationType $type
+    $params = @{
+        ObjectId = $AppObjectId
+        DestinationHost = $DestHost
+        Ports = $ports
+        Protocol = $protocol
+        DestinationType = $type
+    }
+
+    New-EntraBetaPrivateAccessApplicationSegment @params
 }
 ```
-
 
 ## Parameters
 
 ### -ObjectId
-The object id of a Private Access application object.
+
+The object ID of a Private Access application object.
 
 ```yaml
-Type: String
-Parameter Sets: 
+Type: System.String
+Parameter Sets:
 Aliases: id
 
 Required: True
@@ -98,11 +121,12 @@ Accept wildcard characters: False
 ```
 
 ### -DestinationHost
+
 Destination host for the application segment. It can be an IP address, a range of IPs (10.10.10.1..10.10.10.200), a CIDR range (10.1.1.0/24) or an FQDN (ssh.contoso.local). Additionally, DNS suffixes for Quick Access can be created with dnsSuffix.
 
 ```yaml
-Type: String
-Parameter Sets: 
+Type: System.String
+Parameter Sets:
 Aliases:
 
 Required: True
@@ -113,11 +137,12 @@ Accept wildcard characters: False
 ```
 
 ### -Ports
+
 Ports for the application segment. It can be a single port, a range (1..100) or a list (22,3389).
 
 ```yaml
 Type: System.Collections.Generic.List`1[System.String]
-Parameter Sets: 
+Parameter Sets:
 Aliases:
 
 Required: False
@@ -128,11 +153,12 @@ Accept wildcard characters: False
 ```
 
 ### -Protocol
+
 Protocol for the application segment. It can be a single protocol (TCP) or a list (TCP,UDP).
 
 ```yaml
 Type: System.Collections.Generic.List`1[System.String]
-Parameter Sets: 
+Parameter Sets:
 Aliases:
 
 Required: False
@@ -143,11 +169,12 @@ Accept wildcard characters: False
 ```
 
 ### -DestinationType
+
 Destination type for the application segment. It can be "ipAddress", "dnsSuffix", "ipRangeCidr", "ipRange", or "FQDN".
 
 ```yaml
-Type: String
-Parameter Sets: 
+Type: System.String
+Parameter Sets:
 Aliases:
 
 Required: True
@@ -157,18 +184,20 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## Inputs
 
 ### System.String
+
 System.Nullable\`1\[\[System. Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\]\] System.Nullable\`1\[\[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\]\]
 
 ## Outputs
 
 ### System.Object
+
 ## Notes
 
 ## RELATED LINKS

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaPrivateAccessApplicationSegment.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Remove-EntraBetaPrivateAccessApplicationSegment.md
@@ -17,21 +17,25 @@ schema: 2.0.0
 # Remove-EntraBetaPrivateAccessApplicationSegment
 
 ## Synopsis
+
 The Remove-EntraBetaPrivateAccessApplicationSegment cmdlet deletes an application segments associated to a Private Access application.
 
 ## Description
+
 The Remove-EntraBetaPrivateAccessApplicationSegment cmdlet deletes an application segments associated to a Private Access application.
 
 ## Examples
 
 ### Example 1: Delete an application segment
+
 ```powershell
-PS C:\> Remove-EntraBetaPrivateAccessApplicationSegment -ObjectId b97db9dd-85c7-4365-ac05-bd824728ab83 -ApplicationSegmentId 89a0ff5a-0440-4411-8f1c-d4e0be0635c8
+Remove-EntraBetaPrivateAccessApplicationSegment -ObjectId b97db9dd-85c7-4365-ac05-bd824728ab83 -ApplicationSegmentId 89a0ff5a-0440-4411-8f1c-d4e0be0635c8
 ```
 
 ## Parameters
 
 ### -ObjectId
+
 The object id of a Private Access application object.
 
 ```yaml
@@ -47,6 +51,7 @@ Accept wildcard characters: False
 ```
 
 ### -ApplicationSegmentId
+
 The application segment id of the application segment to be deleted.
 
 ```yaml
@@ -62,16 +67,19 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
+
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## Inputs
 
 ### System.String
+
 System.Nullable\`1\[\[System. Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\]\] System.Nullable\`1\[\[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\]\]
 
 ## Outputs
 
 ### System.Object
+
 ## Notes
 
 ## RELATED LINKS


### PR DESCRIPTION
In this PR, I have added recommendations such as:
- Removed command prompt e.g. C:\>
- Bumped Acrolinx quality score for documentation.
- Added example suggestions e.g. added a command to get an application object.
- Added full data type e.g. System.String instead of String.
- Replaced real GUIDs with fake GUIDs as part of SFI work.
- Added related commands in the `Related Links` section.