### PR TITLE
Global Secure Access Review suggestions

### DIFF
--- a/module/EntraBeta/AdditionalFunctions/Enable-EntraBetaGlobalSecureAccessTenant.ps1
+++ b/module/EntraBeta/AdditionalFunctions/Enable-EntraBetaGlobalSecureAccessTenant.ps1
@@ -1,7 +1,7 @@
 # ------------------------------------------------------------------------------
 #  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 # ------------------------------------------------------------------------------
-function New-EntraBetaGlobalSecureAccessTenant {
+function Enable-EntraBetaGlobalSecureAccessTenant {
 
     PROCESS {  
     $customHeaders = New-EntraBetaCustomHeaders -Command $MyInvocation.MyCommand

--- a/module/EntraBeta/AdditionalFunctions/Get-EntraBetaPrivateAccessApplication.ps1
+++ b/module/EntraBeta/AdditionalFunctions/Get-EntraBetaPrivateAccessApplication.ps1
@@ -5,7 +5,7 @@ function Get-EntraBetaPrivateAccessApplication {
 
 	[CmdletBinding(DefaultParameterSetName = 'AllPrivateAccessApps')]
 	param (
-
+		[Alias("ObjectId")]
 		[Parameter(Mandatory = $True, Position = 1, ParameterSetName = 'SingleAppID')]
 		[string]
 		$ApplicationId,

--- a/module/EntraBeta/AdditionalFunctions/Get-EntraBetaPrivateAccessApplication.ps1
+++ b/module/EntraBeta/AdditionalFunctions/Get-EntraBetaPrivateAccessApplication.ps1
@@ -8,7 +8,7 @@ function Get-EntraBetaPrivateAccessApplication {
 
 		[Parameter(Mandatory = $True, Position = 1, ParameterSetName = 'SingleAppID')]
 		[string]
-		$ObjectID,
+		$ApplicationId,
 		
 		[Parameter(Mandatory = $False, ParameterSetName = 'SingleAppName')]
 		[string]
@@ -25,7 +25,7 @@ function Get-EntraBetaPrivateAccessApplication {
 			break
 		}			
 		"SingleAppID" {
-			Invoke-GraphRequest -Method GET -Headers $customHeaders -OutputType PSObject -Uri "https://graph.microsoft.com/beta/applications/$ObjectID/?`$select=displayName,appId,id,tags,createdDateTime,servicePrincipalType,createdDateTime,servicePrincipalNames"
+			Invoke-GraphRequest -Method GET -Headers $customHeaders -OutputType PSObject -Uri "https://graph.microsoft.com/beta/applications/$ApplicationId/?`$select=displayName,appId,id,tags,createdDateTime,servicePrincipalType,createdDateTime,servicePrincipalNames"
 			break
 		}
 		"SingleAppName" {

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Enable-EntraBetaGlobalSecureAccessTenant.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Enable-EntraBetaGlobalSecureAccessTenant.md
@@ -1,6 +1,6 @@
 ---
-title: New-EntraBetaGlobalSecureAccessTenant
-description: This article provides details on the New-EntraBetaGlobalSecureAccessTenant command.
+title: Enable-EntraBetaGlobalSecureAccessTenant
+description: This article provides details on the Enable-EntraBetaGlobalSecureAccessTenant command.
 
 ms.topic: reference
 ms.date: 10/19/2024
@@ -14,7 +14,7 @@ online version:
 schema: 2.0.0
 ---
 
-# New-EntraBetaGlobalSecureAccessTenant
+# Enable-EntraBetaGlobalSecureAccessTenant
 
 ## Synopsis
 
@@ -22,7 +22,7 @@ Onboard the Global Secure Access service in the tenant.
 
 ## Description
 
-The `New-EntraBetaGlobalSecureAccessTenant` cmdlet onboards the Global Secure Access service in the tenant.
+The `Enable-EntraBetaGlobalSecureAccessTenant` cmdlet onboards the Global Secure Access service in the tenant.
 
 In delegated scenarios with work or school accounts, the signed-in user needs a supported Microsoft Entra role or a custom role with the necessary permissions:
 
@@ -35,7 +35,7 @@ In delegated scenarios with work or school accounts, the signed-in user needs a 
 
 ```powershell
 Connect-Entra -Scopes 'NetworkAccessPolicy.ReadWrite.All', 'Application.ReadWrite.All', 'NetworkAccess.ReadWrite.All'
-New-EntraBetaGlobalSecureAccessTenant
+Enable-EntraBetaGlobalSecureAccessTenant
 ```
 
 ```Output

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaGlobalSecureAccessTenantStatus.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaGlobalSecureAccessTenantStatus.md
@@ -40,9 +40,9 @@ Get-EntraBetaGlobalSecureAccessTenantStatus
 ```
 
 ```Output
-@odata.context         : https://graph.microsoft.com/beta/$metadata#networkAccess/tenantStatus/$entity
-onboardingStatus       : onboarded
-onboardingErrorMessage :
+@odata.context                                                                onboardingStatus onboardingErrorMessage
+--------------                                                                ---------------- ----------------------
+https://graph.microsoft.com/beta/$metadata#networkAccess/tenantStatus/$entity offboarded
 ```
 
 This command retrieves the onboarding status of the Global Secure Access service in the tenant.

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaGlobalSecureAccessTenantStatus.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaGlobalSecureAccessTenantStatus.md
@@ -22,12 +22,20 @@ Retrieves the onboarding status of the Global Secure Access service in the tenan
 
 ## Description
 
-The `Get-EntraBetaGlobalSecureAccessTenantStatus` cmdlet retrieves the onboarding status of the Global Secure Access service in the tenant
+The `Get-EntraBetaGlobalSecureAccessTenantStatus` cmdlet retrieves the onboarding status of the Global Secure Access service in the tenant.
 
-## Example
+For delegated scenarios involving work or school accounts, the signed-in user must have either a supported Microsoft Entra role or a custom role with the necessary permissions. The following least-privileged roles are supported for this operation:
+
+- Global Reader
+- Global Secure Access Administrator
+- Security Administrator
+
+## Examples
+
+### Example 1: Check Global Secure Access status for the tenant
 
 ```powershell
-Connect-Entra -Scopes 'NetworkAccessPolicy.ReadWrite.All', 'Application.ReadWrite.All', 'NetworkAccess.ReadWrite.All'
+Connect-Entra -Scopes 'NetworkAccessPolicy.Read.All'
 Get-EntraBetaGlobalSecureAccessTenantStatus
 ```
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaGlobalSecureAccessTenantStatus.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaGlobalSecureAccessTenantStatus.md
@@ -45,7 +45,9 @@ Get-EntraBetaGlobalSecureAccessTenantStatus
 https://graph.microsoft.com/beta/$metadata#networkAccess/tenantStatus/$entity offboarded
 ```
 
-This command retrieves the onboarding status of the Global Secure Access service in the tenant.
+This command checks if the Global Secure Access service is activated in the tenant.
+
+If the status is `offboarded`, you can activate the service with `New-EntraBetaGlobalSecureAccessTenant`.
 
 ### CommonParameters
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaGlobalSecureAccessTenantStatus.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaGlobalSecureAccessTenantStatus.md
@@ -74,4 +74,3 @@ System.Nullable\`1\[\[System. Boolean, mscorlib, Version=4.0.0.0, Culture=neutra
 [Remove-EntraBetaPrivateAccessApplicationSegment](Remove-EntraBetaPrivateAccessApplicationSegment.md)
 
 [New-EntraBetaPrivateAccessApplicationSegment](New-EntraBetaPrivateAccessApplicationSegment.md)
-

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaGlobalSecureAccessTenantStatus.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaGlobalSecureAccessTenantStatus.md
@@ -49,6 +49,8 @@ This command checks if the Global Secure Access service is activated in the tena
 
 If the status is `offboarded`, you can activate the service with `New-EntraBetaGlobalSecureAccessTenant`.
 
+The onboarding status can be: `offboarded`, `offboarding in progress`, `onboarding in progress`, `onboarded`, `onboarding error`, or `offboarding error`.
+
 ### CommonParameters
 
 This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaGlobalSecureAccessTenantStatus.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaGlobalSecureAccessTenantStatus.md
@@ -35,7 +35,7 @@ For delegated scenarios involving work or school accounts, the signed-in user mu
 ### Example 1: Check Global Secure Access status for the tenant
 
 ```powershell
-Connect-Entra -Scopes 'NetworkAccessPolicy.Read.All'
+Connect-Entra -Scopes 'NetworkAccessPolicy.ReadWrite.All', 'Application.ReadWrite.All', 'NetworkAccess.ReadWrite.All'
 Get-EntraBetaGlobalSecureAccessTenantStatus
 ```
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaPrivateAccessApplication.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaPrivateAccessApplication.md
@@ -35,14 +35,14 @@ Get-EntraBetaPrivateAccessApplication
 
 ```Output
 displayName     : testApp1
-appId           : b8a10d3c-0000-4d0b-9b31-d24a097a1e02
-id              : 8f139194-c876-0000-af51-8aeb7f1fb9d4
+appId           : aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb
+id              : bbbbbbbb-1111-2222-3333-cccccccccccc
 tags            : {IsAccessibleViaZTNAClient, HideApp, PrivateAccessNonWebApplication}
 createdDateTime : 14/06/2024 12:38:50 AM
 
 displayName     : QuickAccess
-appId           : d2d253be-0000-4d93-a5e4-5c0aca66ef5e
-id              : a3bdc7a8-e7af-0000-abe7-4f093d2141d8
+appId           : dddddddd-3333-4444-5555-eeeeeeeeeeee
+id              : eeeeeeee-4444-5555-6666-ffffffffffff
 tags            : {HideApp, NetworkAccessQuickAccessApplication}
 createdDateTime : 4/07/2023 4:00:07 AM
 ```
@@ -53,14 +53,14 @@ This command retrieves all Private Access applications, including Quick Access.
 
 ```powershell
 Connect-Entra -Scopes 'NetworkAccessPolicy.ReadWrite.All', 'Application.ReadWrite.All', 'NetworkAccess.ReadWrite.All'
-
-Get-EntraBetaPrivateAccessApplication -ObjectID a3bdc7a8-e7af-0000-abe7-4f093d2141d8
+$application = Get-EntraBetaPrivateAccessApplication | Where-Object {$_.DisplayName -eq 'Finance team file share'}
+Get-EntraBetaPrivateAccessApplication -ApplicationId $application.Id
 ```
 
 ```Output
 displayName     : QuickAccess
-appId           : d2d253be-0000-4d93-a5e4-5c0aca66ef5e
-id              : a3bdc7a8-e7af-0000-abe7-4f093d2141d8
+appId           : aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb
+id              : bbbbbbbb-1111-2222-3333-cccccccccccc
 tags            : {HideApp, NetworkAccessQuickAccessApplication}
 createdDateTime : 4/07/2023 4:00:07 AM
 ```
@@ -71,14 +71,13 @@ This example demonstrates how to retrieve information for a specific Private Acc
 
 ```powershell
 Connect-Entra -Scopes 'NetworkAccessPolicy.ReadWrite.All', 'Application.ReadWrite.All', 'NetworkAccess.ReadWrite.All'
-
-Get-EntraBetaPrivateAccessApplication -ApplicationName testApp1
+Get-EntraBetaPrivateAccessApplication -ApplicationName 'Finance team file share'
 ```
 
 ```Output
-displayName     : testApp1
-appId           : b8a10d3c-0000-4d0b-9b31-d24a097a1e02
-id              : 8f139194-c876-0000-af51-8aeb7f1fb9d4
+displayName     : Finance team file share
+appId           : aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb
+id              : bbbbbbbb-1111-2222-3333-cccccccccccc
 tags            : {IsAccessibleViaZTNAClient, HideApp, PrivateAccessNonWebApplication}
 createdDateTime : 14/06/2024 12:38:50 AM
 ```
@@ -87,7 +86,7 @@ This example demonstrates how to retrieve information for a specific Private Acc
 
 ## Parameters
 
-### -ObjectId
+### -ApplicationId
 
 The Object ID of a Private Access application object.
 
@@ -144,4 +143,3 @@ System.Nullable\`1\[\[System. Boolean, mscorlib, Version=4.0.0.0, Culture=neutra
 [Remove-EntraBetaPrivateAccessApplicationSegment](Remove-EntraBetaPrivateAccessApplicationSegment.md)
 
 [New-EntraBetaPrivateAccessApplicationSegment](New-EntraBetaPrivateAccessApplicationSegment.md)
-

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaPrivateAccessApplication.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/Get-EntraBetaPrivateAccessApplication.md
@@ -93,7 +93,7 @@ The Object ID of a Private Access application object.
 ```yaml
 Type: System.String
 Parameter Sets: SingleAppID
-Aliases: 
+Aliases: ObjectId
 
 Required: False
 Position: 1

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaGlobalSecureAccessTenant.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaGlobalSecureAccessTenant.md
@@ -34,7 +34,7 @@ In delegated scenarios with work or school accounts, the signed-in user needs a 
 ### Example 1: Enable Global Secure Access for a tenant
 
 ```powershell
-Connect-Entra -Scopes 'NetworkAccessPolicy.ReadWrite.All'
+Connect-Entra -Scopes 'NetworkAccessPolicy.ReadWrite.All', 'Application.ReadWrite.All', 'NetworkAccess.ReadWrite.All'
 New-EntraBetaGlobalSecureAccessTenant
 ```
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaGlobalSecureAccessTenant.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaGlobalSecureAccessTenant.md
@@ -24,7 +24,7 @@ Onboard the Global Secure Access service in the tenant.
 
 The `New-EntraBetaGlobalSecureAccessTenant` cmdlet onboards the Global Secure Access service in the tenant.
 
-In delegated scenarios with work or school accounts, the signed-in user must have a supported Microsoft Entra role or a custom role with the necessary permissions. The following least-privileged roles are supported:
+In delegated scenarios with work or school accounts, the signed-in user needs a supported Microsoft Entra role or a custom role with the necessary permissions:
 
 - Global Secure Access Administrator
 - Security Administrator
@@ -65,5 +65,3 @@ System.Nullable\`1\[\[System. Boolean, mscorlib, Version=4.0.0.0, Culture=neutra
 ## RELATED LINKS
 
 [Get-EntraBetaGlobalSecureAccessTenantStatus](Get-EntraBetaGlobalSecureAccessTenantStatus.md)
-
-

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaGlobalSecureAccessTenant.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaGlobalSecureAccessTenant.md
@@ -24,10 +24,17 @@ Onboard the Global Secure Access service in the tenant.
 
 The `New-EntraBetaGlobalSecureAccessTenant` cmdlet onboards the Global Secure Access service in the tenant.
 
-## Example
+In delegated scenarios with work or school accounts, the signed-in user must have a supported Microsoft Entra role or a custom role with the necessary permissions. The following least-privileged roles are supported:
+
+- Global Secure Access Administrator
+- Security Administrator
+
+## Examples
+
+### Example 1: Enable Global Secure Access for a tenant
 
 ```powershell
-Connect-Entra -Scopes 'NetworkAccessPolicy.ReadWrite.All', 'Application.ReadWrite.All', 'NetworkAccess.ReadWrite.All'
+Connect-Entra -Scopes 'NetworkAccessPolicy.ReadWrite.All'
 New-EntraBetaGlobalSecureAccessTenant
 ```
 

--- a/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaPrivateAccessApplication.md
+++ b/module/docs/entra-powershell-beta/Microsoft.Graph.Entra.Beta/New-EntraBetaPrivateAccessApplication.md
@@ -32,6 +32,7 @@ The `New-EntraBetaPrivateAccessApplication` cmdlet creates a Private Access appl
 Connect-Entra -Scopes 'NetworkAccessPolicy.ReadWrite.All', 'Application.ReadWrite.All', 'NetworkAccess.ReadWrite.All'
 New-EntraBetaPrivateAccessApplication -ApplicationName TestApp1
 ```
+
 This example demonstrates how to create a new Private Access application called TestApp1 and assign the default connector group to it.
 
 ### Example 2: Create a new Private Access app and assign a specific connector group
@@ -40,6 +41,7 @@ This example demonstrates how to create a new Private Access application called 
 Connect-Entra -Scopes 'NetworkAccessPolicy.ReadWrite.All', 'Application.ReadWrite.All', 'NetworkAccess.ReadWrite.All'
 New-EntraBetaPrivateAccessApplication -ApplicationName TestApp1 -ConnectorGroupId a3bdc7a8-e7af-0000-abe7-4f093d2141d8
 ```
+
 This example demonstrates how to create a new Private Access application called TestApp1 and assign a specific connector group to it.
 
 ## Parameters
@@ -101,4 +103,3 @@ System.Nullable\`1\[\[System. Boolean, mscorlib, Version=4.0.0.0, Culture=neutra
 [Remove-EntraBetaPrivateAccessApplicationSegment](Remove-EntraBetaPrivateAccessApplicationSegment.md)
 
 [New-EntraBetaPrivateAccessApplicationSegment](New-EntraBetaPrivateAccessApplicationSegment.md)
-


### PR DESCRIPTION
Global Secure Access Review suggestions:

- Renamed the command `New-EntraBetaGlobalSecureAccessTenant` to `Enable-EntraBetaGlobalSecureAccessTenant`.
- Replaced `ObjectId` with `ApplicationId` for command - `Get-EntraBetaPrivateAccessApplication` which is more intuitive, and added aliases.
- Replaced example outputs with anonymized GUID values instead of real GUIDs.
- Run Acrolinx to ensure >80% docs quality score.
- Removed trailing spaces as per recommendations from Learn Authoring pack extension.
- Fixed Example header formats which were resulting in build errors.